### PR TITLE
Refactor device selection to use client_state_t

### DIFF
--- a/include/input.h
+++ b/include/input.h
@@ -105,10 +105,10 @@ bool choose_client(uint32_t *client_index);
  * @brief Prompts the user to select a GPIO device to modify.
  *
  * @param device_index Output pointer for selected index (1-based).
- * @param running_client_state The state structure of the selected client.
+ * @param client_state The state structure of the selected client.
  * @return true if valid device selected, false otherwise.
  */
-bool choose_device(uint32_t *device_index, const client_t *client);
+bool choose_device(uint32_t *device_index, const client_state_t *client_state);
 
 /**
  * @brief Prompts the user to enter a desired state: ON (1) or OFF (0).

--- a/include/server.h
+++ b/include/server.h
@@ -83,6 +83,26 @@ void server_print_running_client_state(const client_t *);
  */
 void server_print_client_preset_configuration(const client_t *, uint8_t);
 
+/**
+ * @brief Prints the state of all devices from a given client state structure.
+ *
+ * - Iterates through all available GPIO devices.
+ * - Prints each device's state using `server_print_gpio_state()`.
+ * - Skips devices used for UART communication.
+ *
+ * @param client_state Pointer to the client_state_t structure to display.
+ */
+void server_print_state_devices(const client_state_t *client_state);
+
+/**
+ * @brief Prints all preset configurations for a client.
+ *
+ * - Iterates through each preset slot of the client.
+ * - Prints each configuration using `server_print_client_preset_configuration()`.
+ * - Adds spacing between configurations for clarity.
+ *
+ * @param client Pointer to the client_t structure containing the preset configurations.
+ */
 void server_print_client_preset_configurations(const client_t *);
 
 /**

--- a/server/input.c
+++ b/server/input.c
@@ -131,14 +131,14 @@ bool choose_state(uint32_t *device_state){
     return false;
 }
 
-bool choose_device(uint32_t *device_index, const client_t *client){  
+bool choose_device(uint32_t *device_index, const client_state_t *client_state){  
     printf("\n");
-    server_print_running_client_state(client);
+    server_print_state_devices(client_state);
 
     const char *MESSAGE = "\nWhat device number do you want to access?";
     print_cancel_message();
     if (read_user_choice_in_range(MESSAGE, device_index, MINIMUM_DEVICE_INDEX_INPUT, MAXIMUM_DEVICE_INDEX_INPUT)){
-        if (client->running_client_state.devices[*device_index - 1].gpio_number != UART_CONNECTION_FLAG_NUMBER){
+        if (client_state->devices[*device_index - 1].gpio_number != UART_CONNECTION_FLAG_NUMBER){
             return true;
         }else{
             printf("Selected device is used as UART connection.\n");

--- a/server/state_handling.c
+++ b/server/state_handling.c
@@ -249,7 +249,7 @@ void server_configure_persistent_state(server_persistent_state_t *server_persist
     save_server_state(server_persistent_state);
 }
 
-static void server_print_state_devices(const client_state_t *client_state){
+void server_print_state_devices(const client_state_t *client_state){
     for (uint8_t gpio_index = 0; gpio_index < MAX_NUMBER_OF_GPIOS; gpio_index++){
         server_print_gpio_state(gpio_index, client_state);
     }


### PR DESCRIPTION
Updated choose_device and related functions to accept client_state_t instead of client_t, improving clarity between client configuration and runtime state. Added server_print_state_devices to server.h and made it public. Refactored menu and configuration logic to use the new signatures and improved documentation for related functions.