### PR TITLE
Add periodic onboard LED blink and fast blink command support for clients

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -43,6 +43,10 @@
 #define LED_DELAY_MS 125
 #endif
 
+#ifndef FAST_LED_DELAY_MS
+#define FAST_LED_DELAY_MS 25
+#endif
+
 /// Timeout in milliseconds for receiving a UART connection request.
 /// Minimum effective value is ~300ms. 500ms provides more robustness.
 #ifndef SERVER_TIMEOUT_MS

--- a/include/config.h
+++ b/include/config.h
@@ -84,5 +84,8 @@
 #define TRIGGER_RESET_FLAG_NUMBER 77
 #endif
 
+#ifndef BLINK_ONBOARD_LED_FLAG_NUMBER
+#define BLINK_ONBOARD_LED_FLAG_NUMBER 66
+#endif
 
 #endif

--- a/include/functions.h
+++ b/include/functions.h
@@ -80,6 +80,12 @@ void pico_set_onboard_led(bool state);
  */
 void blink_onboard_led(void);
 
+/**
+ * @brief Performs a quick blink of the onboard LED.
+ *
+ * Turns the onboard LED on, waits for a short delay (`FAST_LED_DELAY_MS`),
+ * then turns it off. Used as a visual indicator for events like client pings.
+ */
 void fast_blink_onboard_led(void);
 
 /**

--- a/include/functions.h
+++ b/include/functions.h
@@ -80,6 +80,8 @@ void pico_set_led(bool state);
  */
 void blink_onboard_led(void);
 
+void fast_blink_onboard_led(void);
+
 /**
  * @brief Resets the TX and RX pins to default SIO mode.
  *

--- a/include/functions.h
+++ b/include/functions.h
@@ -66,14 +66,14 @@ void get_uart_buffer(uart_inst_t *uart, char *buffer, uint8_t buffer_size, uint3
  *
  * @return int Returns `PICO_OK` on success, or `-1` if no LED config is found.
  */
-int pico_led_init(void);
+int pico_onboard_led_init(void);
 
 /**
  * @brief Turns the onboard LED on or off.
  * 
  * @param led_on true to turn on the LED, false to turn it off
  */
-void pico_set_led(bool state);
+void pico_set_onboard_led(bool state);
 
 /**
  * @brief Blinks the onboard LED 5 times with a defined delay.
@@ -99,6 +99,6 @@ static inline void reset_gpio_pins(uart_pin_pair_t pin_pair){
  *
  * Turns on the onboard LED and sets up the USB serial connection.
  */
-void init_led_and_usb(void);
+void init_onboard_led_and_usb(void);
 
 #endif

--- a/include/menu.h
+++ b/include/menu.h
@@ -21,8 +21,16 @@
 #define PERIODIC_CONSOLE_CHECK_TIME_MS 2000
 #endif
 
-#ifndef INTERCORE_WAKEUP_MESSAGE
-#define INTERCORE_WAKEUP_MESSAGE 0xBFFEBFFE
+#ifndef PERIODIC_ONBOARD_LED_BLINK_TIME_MS
+#define PERIODIC_ONBOARD_LED_BLINK_TIME_MS 2500
+#endif
+
+#ifndef DUMP_BUFFER_WAKEUP_MESSAGE
+#define DUMP_BUFFER_WAKEUP_MESSAGE 0xBFFEBFFE
+#endif
+
+#ifndef BLINK_LED_WAKEUP_MESSAGE
+#define BLINK_LED_WAKEUP_MESSAGE 0xEDEDEDED
 #endif
 
 extern volatile char reconnection_buffer[BUFFER_MAX_NUMBER_OF_STRINGS][BUFFER_MAX_STRING_SIZE];
@@ -38,7 +46,7 @@ extern volatile uint32_t reconnection_buffer_index;
  */
 void server_display_menu(void);
 
-void print_buffer();
+void periodic_wakeup();
 
 void print_and_update_buffer(const char *string);
 

--- a/include/server.h
+++ b/include/server.h
@@ -125,6 +125,8 @@ void server_print_client_preset_configurations(const client_t * client);
  */
 void signal_reset_for_all_clients();
 
+void send_fast_blink_onboard_led_to_clients();
+
 /**
  * @brief Configures the devices for a given client and preset configuration index.
  *

--- a/include/server.h
+++ b/include/server.h
@@ -117,14 +117,17 @@ void server_print_client_preset_configuration(const client_t * client, uint8_t c
 void server_print_client_preset_configurations(const client_t * client);
 
 /**
- * @brief Sends a reset signal to all active UART clients.
+ * @brief Sends a reset trigger message to all clients.
  *
- * Iterates through all active UART connections and sends a formatted
- * reset message (`"[<code>,<code>]"`) over UART. Waits for TX completion
- * and resets the associated GPIO pins.
+ * This causes each connected client to perform a full reset of its internal state.
  */
 void signal_reset_for_all_clients();
 
+/**
+ * @brief Sends a fast onboard LED blink signal to all clients.
+ *
+ * Triggers a visual blink (e.g., heartbeat) on each client device.
+ */
 void send_fast_blink_onboard_led_to_clients();
 
 /**

--- a/src/client/apply_commands.c
+++ b/src/client/apply_commands.c
@@ -18,15 +18,17 @@
 #include "functions.h"
 
 /**
- * @brief Applies a GPIO command based on a received byte pair.
+ * @brief Applies an action to a GPIO pin or handles control flags based on a received byte pair.
  *
- * If the byte pair matches the reset trigger, a watchdog reset is initiated.
- * Otherwise, the function initializes the target GPIO pin, sets it as output,
- * and writes the desired value.
+ * Interprets the two-byte input and performs one of the following:
+ * - If both bytes match `TRIGGER_RESET_FLAG_NUMBER`, triggers a full system reset via watchdog.
+ * - If both bytes match `BLINK_ONBOARD_LED_FLAG_NUMBER`, performs a fast onboard LED blink.
+ * - Otherwise, treats the bytes as:
+ *    - [0] = GPIO pin number
+ *    - [1] = Logic level (0 = LOW, 1 = HIGH)
+ *   and applies the command by setting the pin direction and value.
  *
- * @param received_number_pair A pointer to a 2-byte array:
- *        - [0] = GPIO number
- *        - [1] = Value (0 = LOW, 1 = HIGH)
+ * @param received_number_pair Pointer to a 2-byte array containing the command.
  */
 static void apply_command(uint8_t *received_number_pair){
     if (received_number_pair[0] == TRIGGER_RESET_FLAG_NUMBER && received_number_pair[1] == TRIGGER_RESET_FLAG_NUMBER){

--- a/src/client/apply_commands.c
+++ b/src/client/apply_commands.c
@@ -31,11 +31,13 @@
 static void apply_command(uint8_t *received_number_pair){
     if (received_number_pair[0] == TRIGGER_RESET_FLAG_NUMBER && received_number_pair[1] == TRIGGER_RESET_FLAG_NUMBER){
         watchdog_reboot(0, 0, 0);
+    }else if (received_number_pair[0] == BLINK_ONBOARD_LED_FLAG_NUMBER && received_number_pair[1] == BLINK_ONBOARD_LED_FLAG_NUMBER){
+        fast_blink_onboard_led();
+    }else{
+        gpio_init(received_number_pair[0]);
+        gpio_set_dir(received_number_pair[0], GPIO_OUT); 
+        gpio_put(received_number_pair[0], received_number_pair[1]);
     }
-
-    gpio_init(received_number_pair[0]);
-    gpio_set_dir(received_number_pair[0], GPIO_OUT); 
-    gpio_put(received_number_pair[0], received_number_pair[1]);
 }
 
 void client_listen_for_commands(void){

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -25,7 +25,7 @@
  * @return Unused (program loops forever).
  */
 int main(void){
-    init_led_and_usb();
+    init_onboard_led_and_usb();
 
     while(!client_detect_uart_connection()){
         tight_loop_contents();

--- a/src/common/functions.c
+++ b/src/common/functions.c
@@ -98,6 +98,12 @@ void blink_onboard_led(void){
     pico_set_led(false);
 }
 
+void fast_blink_onboard_led(void){
+    pico_set_led(true);
+    sleep_ms(FAST_LED_DELAY_MS);
+    pico_set_led(false);
+}
+
 void init_led_and_usb(void){
     pico_led_init();
     pico_set_led(true);    

--- a/src/common/functions.c
+++ b/src/common/functions.c
@@ -67,7 +67,7 @@ void get_uart_buffer(uart_inst_t* uart, char* buf, uint8_t buffer_size, uint32_t
     buf[idx] = '\0';  
 }
 
-int pico_led_init(void) {
+int pico_onboard_led_init(void) {
 #if defined(CYW43_WL_GPIO_LED_PIN)
     return cyw43_arch_init();
 #elif defined(PICO_DEFAULT_LED_PIN)
@@ -79,7 +79,7 @@ int pico_led_init(void) {
 #endif
 }
 
-void pico_set_led(bool led_on) {
+void pico_set_onboard_led(bool led_on) {
 #if defined(CYW43_WL_GPIO_LED_PIN)
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
 #elif defined(PICO_DEFAULT_LED_PIN)
@@ -90,22 +90,22 @@ void pico_set_led(bool led_on) {
 void blink_onboard_led(void){
     int blink_iterations = 5;
     while (blink_iterations--){
-        pico_set_led(false);
+        pico_set_onboard_led(false);
         sleep_ms(LED_DELAY_MS);
-        pico_set_led(true);
+        pico_set_onboard_led(true);
         sleep_ms(LED_DELAY_MS);
     }
-    pico_set_led(false);
+    pico_set_onboard_led(false);
 }
 
 void fast_blink_onboard_led(void){
-    pico_set_led(true);
+    pico_set_onboard_led(true);
     sleep_ms(FAST_LED_DELAY_MS);
-    pico_set_led(false);
+    pico_set_onboard_led(false);
 }
 
-void init_led_and_usb(void){
-    pico_led_init();
-    pico_set_led(true);    
+void init_onboard_led_and_usb(void){
+    pico_onboard_led_init();
+    pico_set_onboard_led(true);    
     stdio_usb_init();
 }

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -48,7 +48,6 @@ static void usb_irq_handler(void) {
         signal_reset_for_all_clients();
         watchdog_reboot(0, 0, 0);
     }
-
 }
 
 /**
@@ -89,7 +88,9 @@ static void find_clients(void){
 
     blink_onboard_led();
     server_load_running_states_to_active_clients();
+}
 
+static void last_inits_and_display_launch(){
     setup_usb_irq();
     setup_repeating_timer_for_periodic_onboard_led_blink();
 
@@ -100,6 +101,12 @@ static void find_clients(void){
             server_display_menu();
         }
     }
+}
+
+static void entry_point(){
+    init_onboard_led_and_usb();
+    find_clients();
+    last_inits_and_display_launch();
 }
 
 /**
@@ -118,10 +125,8 @@ static void find_clients(void){
 int main(void){
     if (watchdog_caused_reboot()){
         sleep_ms(100);
-        init_led_and_usb();
-        find_clients();
+        entry_point();
     }else{
-        init_led_and_usb();
-        find_clients();
+        entry_point();
     }
 }

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -64,32 +64,49 @@ static void setup_usb_irq(void) {
     }
 }
 
+/**
+ * @brief Repeating timer callback to trigger onboard LED blink on core1.
+ *
+ * Pushes an inter-core message to wake up core1 and trigger LED blinking.
+ *
+ * @param repeating_timer Unused.
+ * @return Always true to keep the timer running.
+ */
 static bool short_onboard_led_blink(repeating_timer_t *repeating_timer){
     multicore_fifo_push_blocking(BLINK_LED_WAKEUP_MESSAGE);
     return true;
 }
 
+/**
+ * @brief Initializes a repeating timer for periodic onboard LED blinking.
+ *
+ * Every `PERIODIC_ONBOARD_LED_BLINK_TIME_MS`, a wakeup message is sent
+ * to core1 for triggering a short LED blink.
+ */
 static void setup_repeating_timer_for_periodic_onboard_led_blink(){
     add_repeating_timer_ms(PERIODIC_ONBOARD_LED_BLINK_TIME_MS, short_onboard_led_blink, NULL, &repeating_timer);
 }
 
 /**
- * @brief Attempts to discover all active UART clients.
+ * @brief Detects UART clients and loads their saved GPIO states.
  *
- * Continuously calls `server_find_connections()` until at least
- * one connection is established. Then:
- * - Blinks onboard LED.
- * - Loads saved GPIO states for clients.
- * - Installs USB IRQ handler.
- * - Enters USB CLI loop via `server_display_menu()`.
+ * Loops until at least one UART connection is detected. After that:
+ * - Loads the last saved GPIO states for each client.
+ * - Performs a confirmation blink.
  */
 static void find_clients(void){
     while(!server_find_connections()) tight_loop_contents();
 
-    blink_onboard_led();
     server_load_running_states_to_active_clients();
+    blink_onboard_led();
 }
 
+/**
+ * @brief Final initialization stage and entry into USB CLI display loop.
+ *
+ * Sets up USB IRQs, starts the LED timer, launches core1, and enters a loop
+ * waiting for USB CLI connections to launch the user interface.
+ */
 static void last_inits_and_display_launch(){
     setup_usb_irq();
     setup_repeating_timer_for_periodic_onboard_led_blink();
@@ -103,6 +120,9 @@ static void last_inits_and_display_launch(){
     }
 }
 
+/**
+ * @brief Initializes LED and USB, detects clients, and enters UI loop.
+ */
 static void entry_point(){
     init_onboard_led_and_usb();
     find_clients();
@@ -112,15 +132,10 @@ static void entry_point(){
 /**
  * @brief Main entry point of the UART server application.
  *
- * Steps:
- * - Initializes USB stdio and onboard LED.
- * - Scans for valid client UART connections via `server_find_connections()`.
- * - Once at least one connection is established:
- *   - Blinks the onboard LED.
- *   - Loads previous GPIO states from internal flash.
- * - Enters a USB CLI loop (if connected).
+ * If the system rebooted due to a watchdog reset, applies a short delay
+ * before continuing initialization. Delegates logic to `entry_point()`.
  *
- * @return int Exit code (not used).
+ * @return Exit code (not used).
  */
 int main(void){
     if (watchdog_caused_reboot()){

--- a/src/server/menu.c
+++ b/src/server/menu.c
@@ -352,6 +352,7 @@ void periodic_wakeup(){
         }
         if (cmd == BLINK_LED_WAKEUP_MESSAGE){
             fast_blink_onboard_led();
+            send_fast_blink_onboard_led_to_clients();
         }
     }
 }

--- a/src/server/state_handling.c
+++ b/src/server/state_handling.c
@@ -47,7 +47,7 @@ void server_print_client_preset_configurations(const client_t *client){
     }
 }
 
-void send_flag_message(const uint8_t FLAG_MESSAGE){
+static void send_flag_message(const uint8_t FLAG_MESSAGE){
        for (uint8_t client_index = 0; client_index < active_server_connections_number; client_index++){
         uart_inst_t* uart_instance = active_uart_server_connections[client_index].uart_instance;
         uart_pin_pair_t pin_pair = active_uart_server_connections[client_index].pin_pair;

--- a/src/server/state_handling.c
+++ b/src/server/state_handling.c
@@ -47,6 +47,15 @@ void server_print_client_preset_configurations(const client_t *client){
     }
 }
 
+/**
+ * @brief Sends a predefined flag message to all connected clients via UART.
+ *
+ * Iterates through all active client connections and sends a message in the format "[X,X]",
+ * where `X` is the specified flag value. Each UART is initialized before sending,
+ * and its pins are reset afterward.
+ *
+ * @param FLAG_MESSAGE The numeric flag value to send (e.g., reset trigger or blink signal).
+ */
 static void send_flag_message(const uint8_t FLAG_MESSAGE){
        for (uint8_t client_index = 0; client_index < active_server_connections_number; client_index++){
         uart_inst_t* uart_instance = active_uart_server_connections[client_index].uart_instance;

--- a/src/server/state_handling.c
+++ b/src/server/state_handling.c
@@ -47,18 +47,26 @@ void server_print_client_preset_configurations(const client_t *client){
     }
 }
 
-void signal_reset_for_all_clients(){
-    for (uint8_t client_index = 0; client_index < active_server_connections_number; client_index++){
+void send_flag_message(const uint8_t FLAG_MESSAGE){
+       for (uint8_t client_index = 0; client_index < active_server_connections_number; client_index++){
         uart_inst_t* uart_instance = active_uart_server_connections[client_index].uart_instance;
         uart_pin_pair_t pin_pair = active_uart_server_connections[client_index].pin_pair;
         uart_init_with_pins(uart_instance, pin_pair, DEFAULT_BAUDRATE);
 
         char msg[8];
-        snprintf(msg, sizeof(msg), "[%d,%d]", TRIGGER_RESET_FLAG_NUMBER, TRIGGER_RESET_FLAG_NUMBER);
+        snprintf(msg, sizeof(msg), "[%d,%d]", FLAG_MESSAGE, FLAG_MESSAGE);
         uart_puts(uart_instance, msg);
         uart_tx_wait_blocking(uart_instance);
         reset_gpio_pins(pin_pair);
-    }
+    } 
+}
+
+void signal_reset_for_all_clients(){
+    send_flag_message(TRIGGER_RESET_FLAG_NUMBER);
+}
+
+void send_fast_blink_onboard_led_to_clients(){
+    send_flag_message(BLINK_ONBOARD_LED_FLAG_NUMBER);
 }
 
 /**


### PR DESCRIPTION
This pull request introduces two main enhancements to the UART server project:
- Periodic onboard LED blinking:
    - Added a repeating timer on core0 that triggers a brief onboard LED blink every 2 seconds.
    - Visual heartbeat to confirm server activity.

- Fast blink command for clients:
    - Introduced a special flag (BLINK_ONBOARD_LED_FLAG_NUMBER) that allows the server to broadcast a "fast blink" command to all connected clients.
    - Clients now recognize this flag and briefly blink their onboard LED when received.

Additional changes:
- Refactored function names for clarity and consistency.
- Improved Doxygen-style documentation for all modified files.