### PR TITLE
Call multicore_fifo_drain on watchdog and wakeup

### DIFF
--- a/src/server/main.c
+++ b/src/server/main.c
@@ -104,6 +104,7 @@ int main(void){
     uart_lock = spin_lock_instance(UART_SPINLOCK_ID);
 
     if (watchdog_caused_reboot()){
+        multicore_fifo_drain();
         sleep_ms(100);
         entry_point();
     }else{

--- a/src/server/menu.c
+++ b/src/server/menu.c
@@ -344,6 +344,7 @@ static void setup_repeating_timer_for_console_activity(){
  * - `BLINK_LED_WAKEUP_MESSAGE`: Triggers fast onboard LED blink and mirrors to clients.
  */
 void periodic_wakeup(){
+    multicore_fifo_drain();
     while (true) {
         __wfe();
         if (multicore_fifo_rvalid()) {
@@ -355,8 +356,7 @@ void periodic_wakeup(){
                     sleep_ms(2); 
                 }
             } 
-    
-            if (cmd == BLINK_LED_WAKEUP_MESSAGE){
+            else if (cmd == BLINK_LED_WAKEUP_MESSAGE){
                 #if PERIODIC_ONBOARD_LED_BLINK_SERVER
                     fast_blink_onboard_led();
                 #endif


### PR DESCRIPTION
Added multicore_fifo_drain() to main.c after watchdog reboot and to menu.c at the start of periodic_wakeup().

This ensures the multicore FIFO is cleared before proceeding, improving reliability after reboots and during periodic wakeup handling.